### PR TITLE
Add #anyHands() convenience method to Frame

### DIFF
--- a/dist/leap/frame.js
+++ b/dist/leap/frame.js
@@ -65,6 +65,10 @@
         }
       }
 
+      Frame.prototype.anyHands = function() {
+        return this.hands.length > 0;
+      };
+
       Frame.prototype.toString = function() {
         return "[Cylon::Leap::Frame id='" + this.id + "' timestamp='" + this.timestamp + "']";
       };

--- a/src/leap/frame.coffee
+++ b/src/leap/frame.coffee
@@ -41,4 +41,6 @@ namespace 'Leap', ->
       gesture._mapFrameObjects(this) for gesture in @gestures
       pointable._mapFrameObjects(this) for pointable in @pointables
 
+    anyHands: -> @hands.length > 0
+
     toString: -> "[Cylon::Leap::Frame id='#{@id}' timestamp='#{@timestamp}']"

--- a/test/dist/specs/leap/frame.spec.js
+++ b/test/dist/specs/leap/frame.spec.js
@@ -80,8 +80,30 @@
           return gesture.hands[0].should.be.eql(hand);
         });
       });
-      return it("exposes a toString function", function() {
+      it("exposes a toString function", function() {
         return frame.toString.should.be.a('function');
+      });
+      return describe('#anyHands', function() {
+        context("when there are hands in the frame", function() {
+          return it("returns true", function() {
+            return expect(frame.anyHands()).to.be["true"];
+          });
+        });
+        return context("when there are no hands in the frame", function() {
+          var originalHands;
+          originalHands = null;
+          before(function() {
+            originalHands = frame.hands;
+            return frame.hands = [];
+          });
+          after(function() {
+            return frame.hands = originalHands;
+          });
+          return it("returns false", function() {
+            frame.hands = [];
+            return expect(frame.anyHands()).to.be["false"];
+          });
+        });
       });
     });
   });

--- a/test/src/specs/leap/frame.spec.coffee
+++ b/test/src/specs/leap/frame.spec.coffee
@@ -67,3 +67,22 @@ describe 'Leap', ->
 
     it "exposes a toString function", ->
       frame.toString.should.be.a 'function'
+
+    describe '#anyHands', ->
+      context "when there are hands in the frame", ->
+        it "returns true", ->
+          expect(frame.anyHands()).to.be.true
+
+      context "when there are no hands in the frame", ->
+        originalHands = null
+
+        before ->
+          originalHands = frame.hands
+          frame.hands = []
+
+        after ->
+          frame.hands = originalHands
+
+        it "returns false", ->
+          frame.hands = []
+          expect(frame.anyHands()).to.be.false


### PR DESCRIPTION
Instead of

``` javascript
frame.hands.length > 0
```

Users can now use:

``` javascript
frame.anyHands()
```

Since most Leap-related Cylon activities will involve using hands to control other bits of hardware, hopefully this can make people's lives a little bit easier.

Also includes a couple quick tests to go along with it.
